### PR TITLE
docs: Add Fedora/CentOS 8 installation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,16 @@ sudo make install
 sudo make uninstall
 ```
 
+#### Fedora/CentOS 8
+
+[Available](https://src.fedoraproject.org/rpms/bpytop) in the Fedora and [EPEL-8 repository](https://fedoraproject.org/wiki/EPEL).
+
+>Installation
+
+``` bash
+sudo dnf install bpytop
+```
+
 ## Configurability
 
 All options changeable from within UI.


### PR DESCRIPTION
Hi. `bpytop` packaged for Fedora/CentOS 8 and now [on QA](https://bodhi.fedoraproject.org/updates/?search=bpytop).