### PR TITLE
Select python interpreter for Shebang at installation time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX ?= /usr/local
 DOCDIR ?= $(PREFIX)/share/bpytop/doc
-PYTHON_INTERPRETER ?= $$(which python)
+PYTHON_INTERPRETER ?= $$(which python3)
 
 all:
 	@echo Run \'make install\' to install bpytop.

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 PREFIX ?= /usr/local
 DOCDIR ?= $(PREFIX)/share/bpytop/doc
+PYTHON_INTERPRETER ?= /usr/bin/python3
 
 all:
 	@echo Run \'make install\' to install bpytop.
 
 install:
+	@$(PYTHON_INTERPRETER) -c "import psutil" || (echo "psutil not installed in $(PYTHON_INTERPRETER)"; exit 1)
+	@echo "#!$(PYTHON_INTERPRETER)" | cat - bpytop.py > temp && mv temp bpytop.py
 	@mkdir -p $(DESTDIR)$(PREFIX)/bin
 	@cp -p bpytop.py $(DESTDIR)$(PREFIX)/bin/bpytop
 	@mkdir -p $(DESTDIR)$(DOCDIR)

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,20 @@
 PREFIX ?= /usr/local
 DOCDIR ?= $(PREFIX)/share/bpytop/doc
-PYTHON_INTERPRETER ?= /usr/bin/python3
+PYTHON_INTERPRETER ?= $$(which python)
 
 all:
 	@echo Run \'make install\' to install bpytop.
 
 install:
 	@$(PYTHON_INTERPRETER) -c "import psutil" || (echo "psutil not installed in $(PYTHON_INTERPRETER)"; exit 1)
-	@echo "#!$(PYTHON_INTERPRETER)" | cat - bpytop.py > temp && mv temp bpytop.py
+	@echo "#!$(PYTHON_INTERPRETER)" | cat - bpytop.py > temp
 	@mkdir -p $(DESTDIR)$(PREFIX)/bin
-	@cp -p bpytop.py $(DESTDIR)$(PREFIX)/bin/bpytop
+	@cp -p temp $(DESTDIR)$(PREFIX)/bin/bpytop
 	@mkdir -p $(DESTDIR)$(DOCDIR)
 	@cp -p README.md $(DESTDIR)$(DOCDIR)
 	@cp -pr themes $(DESTDIR)$(PREFIX)/share/bpytop
 	@chmod 755 $(DESTDIR)$(PREFIX)/bin/bpytop
+	@rm temp
 
 uninstall:
 	@rm -rf $(DESTDIR)$(PREFIX)/bin/bpytop

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ If you want to help speed this up, help with setting up proper testing is welcom
 
 >Install python3 and git with a package manager of you choice
 
->Install psutil python module (sudo might be required)
+>Install psutil python module for your python3 interpreter. If your system interpreter is version 3.6 or later, you can use it.
 
 ``` bash
 python3 -m pip install psutil
@@ -140,11 +140,8 @@ python3 -m pip install psutil
 
 #### Dependencies installation OSX
 
->Install homebrew if not already installed
-
-``` bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-```
+>If you haven't installed git and python 3.6 or later,
+>you can install them via [homebrew](https://brew.sh/). 
 
 >Install python3 if not already installed
 
@@ -152,7 +149,7 @@ python3 -m pip install psutil
 brew install python3 git
 ```
 
->Install psutil python module
+>Install psutil python module for your python3 interpreter. If your system interpreter is version 3.6 or later, you can use it.
 
 ``` bash
 python3 -m pip install psutil
@@ -178,11 +175,18 @@ sudo python3 -m pip install psutil
 
 >Clone and install
 
+
+
 ``` bash
 git clone https://github.com/aristocratos/bpytop.git
 cd bpytop
-sudo make install
+make install
 ```
+>The default interpreter will be `/usr/bin/python3`. If you want to use a different one, you can run `make install PYTHON_INTERPRETER=$YOUR_INTERPRETER`. For example
+```bash
+make install PYTHON_INTERPRETER=$(which python)
+```
+>Just make sure that you've installed `psutil` for the selected interpreter.
 
 >to uninstall it
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ make install PYTHON_INTERPRETER=$(which python)
 >to uninstall it
 
 ``` bash
-sudo make uninstall
+make uninstall
 ```
 
 ## Configurability

--- a/bpytop.py
+++ b/bpytop.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # pylint: disable=not-callable, no-member
 # indent = tab
 # tab-size = 4


### PR DESCRIPTION
discussion at #73.
Features:
- interpreter for shebang gets determined at installation time
- original script is left untouched
- dependency check is performed during installation