### PR TITLE
Standardizing element spacing

### DIFF
--- a/bpytop.py
+++ b/bpytop.py
@@ -1478,7 +1478,7 @@ class Box:
 	@classmethod
 	def draw_update_ms(cls, now: bool = True):
 		update_string: str = f'{CONFIG.update_ms}ms'
-		xpos: int = CpuBox.x + CpuBox.width - len(update_string) - 14
+		xpos: int = CpuBox.x + CpuBox.width - len(update_string) - 15
 		if not "+" in Key.mouse:
 			Key.mouse["+"] = [[xpos + 7 + i, CpuBox.y] for i in range(3)]
 			Key.mouse["-"] = [[CpuBox.x + CpuBox.width - 4 + i, CpuBox.y] for i in range(3)]
@@ -2160,7 +2160,7 @@ class ProcBox(Box):
 				if not "delete" in Key.mouse: Key.mouse["delete"] = [[x+12 + len(proc.search_filter[-10:]) + i, y-1] for i in range(3)]
 			elif "delete" in Key.mouse:
 				del Key.mouse["delete"]
-			out_misc += (f'{Mv.to(y-1, x + 8)}{THEME.proc_box(Symbol.title_left)}{Fx.b if cls.filtering or proc.search_filter else ""}{THEME.hi_fg("f")}{THEME.title}' +
+			out_misc += (f'{Mv.to(y-1, x + 7)}{THEME.proc_box(Symbol.title_left)}{Fx.b if cls.filtering or proc.search_filter else ""}{THEME.hi_fg("f")}{THEME.title}' +
 				("ilter" if not proc.search_filter and not cls.filtering else f' {proc.search_filter[-(10 if w < 83 else w - 74):]}{(Fx.bl + "█" + Fx.ubl) if cls.filtering else THEME.hi_fg(" del")}') +
 				f'{THEME.proc_box(Symbol.title_right)}')
 
@@ -2339,7 +2339,7 @@ class ProcBox(Box):
 			del Key.mouse["scroll_up"], Key.mouse["scroll_down"]
 
 		#* Draw current selection and number of processes
-		out += (f'{Mv.to(y+h, x + w - 3 - len(loc_string))}{THEME.proc_box}{Symbol.h_line*1}{Symbol.title_left}{THEME.title}'
+		out += (f'{Mv.to(y+h, x + w - 3 - len(loc_string))}{THEME.proc_box}{Symbol.title_left}{THEME.title}'
 					f'{Fx.b}{loc_string}{Fx.ub}{THEME.proc_box(Symbol.title_right)}')
 
 		#* Clean up dead processes graphs and counters


### PR DESCRIPTION
This patch standardizes some spacing of elements in the "menu bar" (title bar?) areas for the CPU box and Process box. 

1. In every box corner except the top right (update_ms display), and bottom right (display of selected process / total number of processes), the elements are exactly two character widths away from the corner, which is visually appealing as a standard. This patch moves the update_ms display (top right) and the number of processes display (bottom right) to the left by one character width, to adhere to the two-character standard. There should be no visual display issues with the bottom right element and the "terminate" element up to a process count of 999/999, at a window size of 80x24 or larger. There is one character width of spacing to the left up to process `#9`, two character widths of spacing to the left up to process `#99`, then one character spacing and the capital "H" visual appearance for processes 100-999. 

2. Nearly every element that is near to (and "tied" to when the window expands) another associated element in the UI is allowed to be only a single character width away, forming a neat capital "H" with the graphical line characters. Except for the "filter" displayed element, which is two characters from "proc". Other elements that have more space between them typically have more than one character width by coincidence, such as "mem" and "graph" in the Memory box, and "disks" and "swap" in the Disks box, which each maintain two characters distance from their respective corners and expand away from each other, attached to their own box corners. This patch moves "filter" to the left by one character width, since it moves along with "proc" when the window is expanded. This removes a minor visual anomaly in the overall UI. 

3. The display of "Menu" and "mini" have not been moved in this patch. Since they are somewhat unique "meta" elements relating to the overall application rather than the content of a box, it seems visually logical that they be treated separately and left exactly where they are.