### PR TITLE
changed bpytop.git to bpytop to match AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ pip3 install bpytop --upgrade
 
 ### Arch Linux
 
-Available in the AUR as `bpytop.git`
+Available in the AUR as `bpytop`
 
 https://aur.archlinux.org/packages/bpytop/
 


### PR DESCRIPTION
I changed the AUR package name from bpytop.git to bpytop as seen on the AUR.