### PR TITLE
changed bpytop.git to bpytop to match AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ pip3 install bpytop --upgrade
 
 ### Arch Linux
 
-Available in the AUR as `bpytop.git`
+Available in the AUR as `bpytop`
 
 https://aur.archlinux.org/packages/bpytop/
 


### PR DESCRIPTION
In the README.md Installation section, i changed bpytop.git to bpytop to match with the AUR package name.