### PR TITLE
Spread CPUs accross columns evenly if possible

### DIFF
--- a/bpytop.py
+++ b/bpytop.py
@@ -1772,7 +1772,7 @@ class CpuBox(Box, SubBox):
 				out += f'{cpu.cpu_temp[n][-1]:>4}{THEME.main_fg}°C'
 			out += f'{THEME.div_line(Symbol.v_line)}'
 			cy += 1
-			if cy == bh:
+			if cy > ceil(THREADS/cls.box_columns) and n != THREADS:
 				cc += 1; cy = 1; cx = ccw * cc
 				if cc == cls.box_columns: break
 


### PR DESCRIPTION
This PR tries to spread CPUs accross columns evenly when multiple columns are needed to render the CPU box. I think this provides a more aesthetically pleasing result.

Some screenshot for reference of what I mean visually:

- before
![before](https://user-images.githubusercontent.com/339691/96420335-ac482100-11f5-11eb-8b3d-bb53f8fdfe7c.png)

- after
![after](https://user-images.githubusercontent.com/339691/96420402-c3870e80-11f5-11eb-9654-be44e3da62c5.png)

