### PR TITLE
Added installation instructions for Mageia Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,17 @@ Available from [adrien-overlay](https://github.com/aaaaadrien/adrien-overlay)
 sudo emerge -av sys-process/bpytop
 ```
 
+### Mageia Cauldron (Mageia 8)
+
+Available in Mageia Cauldron and then Mageia 8 when it is released.
+
+>Installation
+
+``` bash
+sudo urpmi bpytop
+sudo dnf install bpytop
+```
+
 ### MX Linux
 
 Available in the MX Test Repo as `bpytop`


### PR DESCRIPTION
I've imported bpytop into Mageia Cauldon and added the instructions for installing it.