### PR TITLE
getloadavg from psutil

### DIFF
--- a/bpytop.py
+++ b/bpytop.py
@@ -2846,7 +2846,7 @@ class CpuCollector(Collector):
 				errlog.exception(f'{e}')
 			else:
 				pass
-		cls.load_avg = [round(lavg, 2) for lavg in os.getloadavg()]
+		cls.load_avg = [round(lavg, 2) for lavg in psutil.getloadavg()]
 		cls.uptime = str(timedelta(seconds=round(time()-psutil.boot_time(),0)))[:-3]
 
 		if CONFIG.check_temp and cls.got_sensors:


### PR DESCRIPTION
I changed the ``os.getloadavg()`` to ``psutil.getloadavg()`` to fix the error:

```
/usr/lib/python3.9/site-packages/bpytop.py", line 2849, in _collect
    cls.load_avg = [round(lavg, 2) for lavg in os.getloadavg()]
AttributeError: module 'os' has no attribute 'getloadavg'
08/01/21 (09:35:18) | WARNING: Exiting with errorcode (1). Runtime 0:00:05
```