### PR TITLE
Redraw NetBox if current network interface is changed due to removal

### DIFF
--- a/bpytop.py
+++ b/bpytop.py
@@ -3555,6 +3555,7 @@ class NetCollector(Collector):
 		if not cls.nic or cls.nic not in up_stat:
 			cls._get_nics()
 			if not cls.nic: return
+			NetBox.redraw = True
 		try:
 			io_all = psutil.net_io_counters(pernic=True)[cls.nic]
 		except KeyError:


### PR DESCRIPTION
Resolves #265

This fixes displayed network interface name not updating to a new one when the currently selected interface is removed.

See https://github.com/aristocratos/bpytop/issues/265#issuecomment-842636763 for more details about the issue.