### PR TITLE
Fix broken color test by testing the values individually

### DIFF
--- a/bpytop.py
+++ b/bpytop.py
@@ -1141,9 +1141,8 @@ class Color:
 				else:
 					raise ValueError(f'RGB dec should be "0-255 0-255 0-255"')
 
-			for i in [0, 1, 2]:
-				if not (0 <= self.dec[i] <= 255):
-					raise ValueError(f'One or more RGB values are out of range: {color}')
+			if not all(0 <= c <= 255 for c in self.dec):
+				raise ValueError(f'One or more RGB values are out of range: {color}')
 
 		except Exception as e:
 			errlog.exception(str(e))

--- a/bpytop.py
+++ b/bpytop.py
@@ -1141,9 +1141,10 @@ class Color:
 				else:
 					raise ValueError(f'RGB dec should be "0-255 0-255 0-255"')
 
-			ct = self.dec[0] + self.dec[1] + self.dec[2]
-			if ct > 255*3 or ct < 0:
-				raise ValueError(f'RGB values out of range: {color}')
+			for i in [0, 1, 2]:
+				if not (0 <= self.dec[i] <= 255):
+					raise ValueError(f'One or more RGB values are out of range: {color}')
+
 		except Exception as e:
 			errlog.exception(str(e))
 			self.escape = ""


### PR DESCRIPTION
Testing if the sum of the color values is within range is flawed because
one out of range value might still not exceed the minimum or maximum
value. Multiple out of range values can even pass the test by cancelling
each other out.

This patch tests each value individually and raises an exception on the
first out of range value.