### PR TITLE
Respect XDG base dir spec for config file

### DIFF
--- a/bpytop.py
+++ b/bpytop.py
@@ -241,7 +241,13 @@ update_check=$update_check
 log_level=$log_level
 ''')
 
-CONFIG_DIR: str = f'{os.path.expanduser("~")}/.config/bpytop'
+
+def get_config_dir():
+	config_home = os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
+	return os.path.join(config_home, 'bpytop')
+
+
+CONFIG_DIR: str = get_config_dir()
 if not os.path.isdir(CONFIG_DIR):
 	try:
 		os.makedirs(CONFIG_DIR)


### PR DESCRIPTION
Basic fix to use the `XDG_CONFIG_HOME` env var if it exists. Doesn't do more sophisticated platform-specific handling (it's an option but I'd personally hand that off to something like [platformdirs](https://github.com/platformdirs/platformdirs/)). 

closes #302 
