### PR TITLE
Recognize \r as enter

### DIFF
--- a/bpytop.py
+++ b/bpytop.py
@@ -840,7 +840,7 @@ class Key:
 	mouse: Dict[str, List[List[int]]] = {}
 	mouse_pos: Tuple[int, int] = (0, 0)
 	escape: Dict[Union[str, Tuple[str, str]], str] = {
-		"\n" :					"enter",
+		("\n", "\r") :			"enter",
 		("\x7f", "\x08") :		"backspace",
 		("[A", "OA") :			"up",
 		("[B", "OB") :			"down",


### PR DESCRIPTION
This seems to break on both Fedora 39 and MacPorts with Python 3.12.

See: https://trac.macports.org/ticket/69284
Closes: #410