### PR TITLE
Add Kanagawa Wave theme

### DIFF
--- a/themes/kanagawa-wave.theme
+++ b/themes/kanagawa-wave.theme
@@ -1,0 +1,90 @@
+
+# Main background, empty for terminal default, need to be empty if you want a transparent background
+theme[main_bg]="#1F1F28"
+
+# Main text color
+theme[main_fg]="#dcd7ba"
+
+# Title color for boxes
+theme[title]="#dcd7ba"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#c8c093"
+
+# Background color of the selected item in processes box
+theme[selected_bg]="#2d4f67"
+
+# Foreground color of the selected item in processes box
+theme[selected_fg]="#c8c093"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#727169"
+
+# Color of text appearing on top of graphs, i.e., uptime and current network graph scaling
+theme[graph_text]="#dcd7ba"
+
+# Background color of the percentage meters
+theme[meter_bg]="#16161d"
+
+# Misc colors for processes box including mini CPU graphs, details memory graph, and details status text
+theme[proc_misc]="#6a9589"
+
+# CPU box outline color
+theme[cpu_box]="#6a9589"
+
+# Memory/disks box outline color
+theme[mem_box]="#98bb6c"
+
+# Net up/down box outline color
+theme[net_box]="#e82424"
+
+# Processes box outline color
+theme[proc_box]="#090618"
+
+# Box divider line and small box line color
+theme[div_line]="#16161d"
+
+# Temperature graph colors
+theme[temp_start]="#6a9589"
+theme[temp_mid]="#957fb8"
+theme[temp_end]="#c8c093"
+
+# CPU graph colors
+theme[cpu_start]="#6a9589"
+theme[cpu_mid]="#e6c384"
+theme[cpu_end]="#7fb4ca"
+
+# Mem/Disk free meter
+theme[free_start]="#ffa066"
+theme[free_mid]="#957fb8"
+theme[free_end]="#c8c093"
+
+# Mem/Disk cached meter
+theme[cached_start]="#ffa066"
+theme[cached_mid]="#e6c384"
+theme[cached_end]="#7fb4ca"
+
+# Mem/Disk available meter
+theme[available_start]="#ffa066"
+theme[available_mid]="#e6c384"
+theme[available_end]="#7fb4ca"
+
+# Mem/Disk used meter
+theme[used_start]="#ffa066"
+theme[used_mid]="#e6c384"
+theme[used_end]="#7fb4ca"
+
+# Download graph colors
+theme[download_start]="#6a9589"
+theme[download_mid]="#7fb4ca"
+theme[download_end]="#e6c384"
+
+# Upload graph colors
+theme[upload_start]="#727169"
+theme[upload_mid]="#957fb8"
+theme[upload_end]="#c8c093"
+
+# Process box color gradient for threads, mem, and CPU usage
+theme[process_start]="#7fb4ca"
+theme[process_mid]="#938aa9"
+theme[process_end]="#dcd7ba"


### PR DESCRIPTION
Added theme for [kanagawa](https://github.com/rebelot/kanagawa.nvim) wave colorscheme.