### PR TITLE
Added: Search for themes relative to binary

### DIFF
--- a/bpytop.py
+++ b/bpytop.py
@@ -256,7 +256,12 @@ if os.path.isdir(f'{os.path.dirname(__file__)}/bpytop-themes'):
 elif os.path.isdir(f'{os.path.dirname(__file__)}/themes'):
 	THEME_DIR = f'{os.path.dirname(__file__)}/themes'
 else:
-	for td in ["/usr/local/", "/usr/", "/snap/bpytop/current/usr/"]:
+	for td in [
+            os.path.dirname(os.path.dirname(__file__)).rstrip("/") + "/",
+            "/usr/local/",
+            "/usr/",
+            "/snap/bpytop/current/usr/"
+        ]:
 		if os.path.isdir(f'{td}share/bpytop/themes'):
 			THEME_DIR = f'{td}share/bpytop/themes'
 			break


### PR DESCRIPTION
When installed in non-default paths (i.e., not /usr or /usr/local), bpytop cannot find its themes in $prefix/share/bpytop/themes. Start from the path of the executable to handle non-default values of $prefix.