### PR TITLE
Fix for ValueError: Sign not allowed in string format specifier

### DIFF
--- a/bpytop.py
+++ b/bpytop.py
@@ -2736,7 +2736,7 @@ class ProcBox(Box):
 						(" " if proc.num_procs > cls.select_max else ""))
 				if selected in ["pid", "program", "arguments"]: selected = "tree"
 			else:
-				label = (f'{THEME.title}{Fx.b}{Mv.to(y, x)}{"Pid:":>7} {"Program:" if prog_len > 8 else "Prg:":<{prog_len}}' + (f'{"Arguments:":<{arg_len-4}}' if arg_len else "") +
+				label = (f'{THEME.title}{Fx.b}{Mv.to(y, x)}{"Pid:":>7} {"Program:" if prog_len > 8 else "Prg:":<{prog_len}}' + (f'{"Arguments:":<{max(arg_len-4, 0)}}' if arg_len else "") +
 					((f'{"Threads:":<9}' if arg_len else f'{"Tr:":^5}') if tr_show else "") + (f'{"User:":<9}' if usr_show else "") + f'Mem%{"Cpu%":>11}{Fx.ub}{THEME.main_fg} ' +
 					(" " if proc.num_procs > cls.select_max else ""))
 				if selected == "program" and prog_len <= 8: selected = "prg"


### PR DESCRIPTION
### Description:
This pull request fixes a `ValueError` in the `ProcBox._draw_fg()` method that occurs when formatting the "Arguments" string. The error is caused by a negative width value in the format specifier, which happens when `arg_len` is less than 4, leading to the expression `arg_len - 4` becoming negative.

### Error Trace:
20/10/24 (12:57:58) | ERROR: Data collection thread failed with exception: Sign not allowed in string format specifier
Traceback (most recent call last):
  File "/usr/bin/bpytop", line 2959, in _runner
    collector._draw()
  File "/usr/bin/bpytop", line 3991, in _draw
    ProcBox._draw_fg()
  File "/usr/bin/bpytop", line 2739, in _draw_fg
    label = (f'{THEME.title}{Fx.b}{Mv.to(y, x)}{"Pid:":>7} {"Program:" if prog_len > 8 else "Prg:":<{prog_len}}' + (f'{"Arguments:":<{arg_len-4}}' if arg_len else "") +
                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Sign not allowed in string format specifier
20/10/24 (12:57:58) | WARNING: Exiting with errorcode (1). Runtime 0:00:00

### Cause:
The issue arises when `arg_len - 4` is negative. String format specifiers in Python do not allow negative width values.

### Fix:
The fix is to ensure that the width value used in the string format specifier is never negative by using the `max()` function to enforce a minimum width of `0` when `arg_len - 4` would be negative.

### Modified Code:
The relevant change is as follows:
```python
(f'{"Arguments:":<{max(arg_len-4, 0)}}' if arg_len else "")
```
